### PR TITLE
Removing border-right element from login page.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Removing border-right element in log in page
+
 ## 10.1.5 (2023-06-29)
 
 - #3209: Fix error when importing the `converse` global with bootstrap modal API

--- a/src/plugins/controlbox/styles/_controlbox.scss
+++ b/src/plugins/controlbox/styles/_controlbox.scss
@@ -397,7 +397,7 @@
 
         &.converse-embedded,
         &.converse-fullscreen{
-            .visible-border-right {
+            .controlbox-panes-visible-border-right {
                 border-right: 0.2rem solid var(--panel-divider-color);
             }
             .toggle-controlbox {

--- a/src/plugins/controlbox/styles/_controlbox.scss
+++ b/src/plugins/controlbox/styles/_controlbox.scss
@@ -397,7 +397,7 @@
 
         &.converse-embedded,
         &.converse-fullscreen{
-            .controlbox-panes {
+            .visible-border-right {
                 border-right: 0.2rem solid var(--panel-divider-color);
             }
             .toggle-controlbox {

--- a/src/plugins/controlbox/templates/controlbox.js
+++ b/src/plugins/controlbox/templates/controlbox.js
@@ -11,9 +11,19 @@ function whenNotConnected (o) {
         return tplSpinner();
     }
     if (o['active-form'] === 'register') {
-        return html`<converse-register-panel></converse-register-panel>`;
+        return html`
+            <div class="controlbox-panes">
+                <div class="controlbox-pane">
+                    <converse-register-panel></converse-register-panel>
+                </div>
+            </div>`;
     }
-    return html`<converse-login-form id="converse-login-panel" class="controlbox-pane fade-in row no-gutters"></converse-login-form>`;
+    return html`
+        <div class="controlbox-panes">
+            <div class="controlbox-pane">
+                <converse-login-form id="converse-login-panel" class="controlbox-pane fade-in row no-gutters"></converse-login-form>
+            </div>
+        </div>`;
 }
 
 
@@ -33,19 +43,18 @@ export default (el) => {
                         </a>
                     `}
             </div>
-            <div class="controlbox-panes">
-                <div class="controlbox-pane">
-                    ${o.connected
-                        ? html`
+            ${o.connected
+                ? html`
+                    <div class="controlbox-panes visible-border-right">
+                        <div class="controlbox-pane">
                             <converse-user-profile></converse-user-profile>
                             <converse-headlines-feeds-list class="controlbox-section"></converse-headlines-feeds-list>
                             <div id="chatrooms" class="controlbox-section"><converse-rooms-list></converse-rooms-list></div>
-                            ${ api.settings.get("authentication") === _converse.ANONYMOUS ? '' :
-                                html`<div id="converse-roster" class="controlbox-section"><converse-roster></converse-roster></div>`
+                            ${ api.settings.get("authentication") === _converse.ANONYMOUS ? '</div></div>' :
+                                html`<div id="converse-roster" class="controlbox-section"><converse-roster></converse-roster></div>
+                                </div></div>`
                             }`
-                        : whenNotConnected(o)
-                    }
-                </div>
-            </div>
+                : whenNotConnected(o)
+            }
         </div>`
 };

--- a/src/plugins/controlbox/templates/controlbox.js
+++ b/src/plugins/controlbox/templates/controlbox.js
@@ -45,15 +45,16 @@ export default (el) => {
             </div>
             ${o.connected
                 ? html`
-                    <div class="controlbox-panes visible-border-right">
+                    <div class="controlbox-panes controlbox-panes-visible-border-right">
                         <div class="controlbox-pane">
                             <converse-user-profile></converse-user-profile>
                             <converse-headlines-feeds-list class="controlbox-section"></converse-headlines-feeds-list>
                             <div id="chatrooms" class="controlbox-section"><converse-rooms-list></converse-rooms-list></div>
-                            ${ api.settings.get("authentication") === _converse.ANONYMOUS ? '</div></div>' :
-                                html`<div id="converse-roster" class="controlbox-section"><converse-roster></converse-roster></div>
-                                </div></div>`
-                            }`
+                            ${ api.settings.get("authentication") === _converse.ANONYMOUS ? '' :
+                                html`<div id="converse-roster" class="controlbox-section"><converse-roster></converse-roster></div>`
+                            }
+                        </div>
+                    </div>`
                 : whenNotConnected(o)
             }
         </div>`


### PR DESCRIPTION
Adding new css class, "controlbox-panes-visible-border-right" that adds the border-right element to the controlbox-panes. Previously every controlbox-panes element had this property.
Inserting new class whenever we want to have the old border-right element. 